### PR TITLE
Auth Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ go build                - build Ldapper
 Usage of ./ldapper:
   -H string
     	Use NTLM authentication
-  -d string
-    	Domain. Only needed if using NTLM authentication.
   -dc string
     	IP address or FQDN of target DC
   -h	Display help menu
@@ -79,14 +77,10 @@ Usage of ./ldapper:
   -socks5 string
     	SOCKS5 Proxy Address (ip:port)
   -u string
-    	Username
-    	If using password auth: 'NetBIOSName/user'
-    	If using NTLM auth: 'username'
+    	Username (username@domain)
 Examples:
-	With Password: 	./ldapper -u '<netbios>/username' -p <password> -dc <ip/FQDN> -s
-	With Hash: 	./ldapper -u <username> -H <hash> -d <domain> -dc <ip/FQDN> -s
-Tips:
-	NetBIOS name can be found with 'nmblookup -A dc-ip' (Linux) or 'nbtstat /a dc-ip' (Windows)
+	With Password: 	./ldapper -u <username@domain> -p <password> -dc <ip/FQDN> -s
+	With Hash: 	./ldapper -u <username@domain> -H <hash> -d <domain> -dc <ip/FQDN> -s
 ```
 
 # LDAPS Support
@@ -102,15 +96,15 @@ Ldapper can be used with a username and password. This is the most common method
 - NetBIOSName/username
 
 ```
-> ./ldapper -u overwatch/hanzo -P "Password123!" -dc 10.10.10.101 -s
+> ./ldapper -u 'hanzo@overwatch.local' -P "Password123!" -dc 10.10.10.101 -s
 ```
 
 ## NTLM
 
-Ldapper can also authenticate with a user's NTLM hash. This method can be used with the `-H` flag. When using this authentication method, the username is input alone (no NetBIOS included) and the domain (-d) argument must be specified.
+Ldapper can also authenticate with a user's NTLM hash. This method can be used with the `-H` flag. 
 
 ```
-> ./ldapper -u hanzo -H OOGNKVJB2TRCYLD26H4DVPF3KBP0SG03 -dc 10.10.10.101 -d overwatch.local -s
+> ./ldapper -u 'hanzo@overwatch.local' -H OOGNKVJB2TRCYLD26H4DVPF3KBP0SG03 -dc 10.10.10.101 -s
 ```
 
 # Query Modules
@@ -263,7 +257,7 @@ Successfully deleted SPN: "blah/blah" for user "hanzo"
 Currently, Ldapper supports logging of stdout to a specified log file. This can be called using the `-o` flag. The log file will be created in the current directory. If the log file already exists, it will be appended to.
 
 ```
-./ldapper -u overwatch/hanzo -P "Password123!" -dc 10.10.10.101 -s -o ldapper.log
+./ldapper -u hanzo@overwatch.local -P "Password123!" -dc 10.10.10.101 -s -o ldapper.log
 ```
 
 # Proxy Support

--- a/main.go
+++ b/main.go
@@ -337,13 +337,6 @@ func main() {
 				spnWriter.Flush()
 				f.Close()
 
-				if opt.logFile != "" && result != "" {
-
-					spnLog := fmt.Sprintf("Ouput written to %s\n", spnOutput)
-					fmt.Println(spnLog)
-					Globals.LogToFile(opt.logFile, spnLog)
-
-                            }
 				if opt.logFile != "" {
 					spnLog = fmt.Sprintf("Output written to %s\n", spnOutput)
 				}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ type FlagOptions struct {
 	username string
 	password string
 	ntlm     string
-	domain   string
 	dc       string
 	scheme   bool
 	logFile  string
@@ -35,10 +34,9 @@ type FlagOptions struct {
 }
 
 func options() *FlagOptions {
-	username := flag.String("u", "", "Username \nIf using password auth: 'NetBIOSName/user'\nIf using NTLM auth: 'username'")
+	username := flag.String("u", "", "Username (username@domain)")
 	password := flag.String("p", "", "Password")
 	ntlm := flag.String("H", "", "Use NTLM authentication")
-	domain := flag.String("d", "", "Domain. Only needed if using NTLM authentication.")
 	dc := flag.String("dc", "", "IP address or FQDN of target DC")
 	scheme := flag.Bool("s", false, "Bind using LDAPS")
 	logFile := flag.String("o", "", "Log file")
@@ -52,7 +50,6 @@ func options() *FlagOptions {
 		username: *username,
 		password: *password,
 		ntlm:     *ntlm,
-		domain:   *domain,
 		dc:       *dc,
 		scheme:   *scheme,
 		logFile:  *logFile,
@@ -75,19 +72,33 @@ func main() {
 
 	fmt.Print(header)
 
+	var conn *ldap.Conn
+	var proxyConn net.Conn
+	var err error
+	var domain string
+        var target []string	
+
+	target = strings.Split(opt.username, "@")
+
+	// Did the user supply the username correctly <user@domain>?
+	if len(target) == 1 {
+	    opt.help = true	
+	}else {
+	    domain = target[1]
+	    // only include username for ntlm auth
+	    if opt.ntlm != "" {
+                opt.username = target[0]
+	    }
+	}
+	
 	// if required flags aren't set, print help
 	if opt.username == "" || opt.dc == "" || (opt.password == "" && opt.ntlm == "") || opt.help {
 		flag.Usage()
 		fmt.Println("Examples:")
-		fmt.Println("\tWith Password: \t./ldapper -u '<netbios>/username' -p <password> -dc <ip/FQDN> -s")
-		fmt.Println("\tWith Hash: \t./ldapper -u <username> -H <hash> -d <domain> -dc <ip/FQDN> -s")
-		fmt.Println("Tips:\n\tNetBIOS name can be found with 'nmblookup -A dc-ip' (Linux) or 'nbtstat /a dc-ip' (Windows)")
+		fmt.Println("\tWith Password: \t./ldapper -u <username@domain> -p <password> -dc <ip/FQDN> -s")
+		fmt.Println("\tWith Hash: \t./ldapper -u <username@domain> -H <hash> -dc <ip/FQDN> -s")
 		os.Exit(1)
 	}
-
-	var conn *ldap.Conn
-	var proxyConn net.Conn
-	var err error
 
 	//Initialize connection with proxy if specified
 	if opt.socks4 != "" || opt.socks4a != "" || opt.socks5 != "" {
@@ -152,11 +163,9 @@ func main() {
 
 	defer conn.Close() //Close connection when done
 
-	//Authenticated Bind
-	opt.username = strings.Replace(opt.username, "/", "\\", -1)
 	// if password option set
 	if opt.password != "" {
-		err = conn.Bind(opt.username, opt.password) //NetBios\user, password
+		err = conn.Bind(opt.username, opt.password) 
 		if err != nil {
 			log.Fatal(err)
 		} else {
@@ -166,13 +175,7 @@ func main() {
 
 	// if ntlm hash option set
 	if opt.ntlm != "" {
-		if opt.domain == "" {
-			log.Fatal("Domain must be set if using NTLM")
-		}
-		if strings.Contains(opt.username, "\\") {
-			log.Fatal("For NTLM, username must not contain '<netbios>\\'")
-		}
-		err = conn.NTLMBindWithHash(opt.domain, opt.username, opt.ntlm) //NetBios\user, ntlm hash
+		err = conn.NTLMBindWithHash(domain, opt.username, opt.ntlm) //NetBios\user, ntlm hash
 		if err != nil {
 			fmt.Print("test\n")
 			log.Fatal(err)
@@ -379,7 +382,8 @@ func main() {
 					fmt.Println(spnLog)
 					Globals.LogToFile(opt.logFile, spnLog)
 
-				}
+                            }
+
 			case "mquota":
 				result := Queries.GetMachineQuota(baseDN, conn)
 				fmt.Println(result)

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func main() {
 
 	// if ntlm hash option set
 	if opt.ntlm != "" {
-		err = conn.NTLMBindWithHash(domain, opt.username, opt.ntlm) //NetBios\user, ntlm hash
+		err = conn.NTLMBindWithHash(domain, opt.username, opt.ntlm) 
 		if err != nil {
 			fmt.Print("test\n")
 			log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 type FlagOptions struct {
-	username string
+	upn string
 	password string
 	ntlm     string
 	dc       string
@@ -34,7 +34,7 @@ type FlagOptions struct {
 }
 
 func options() *FlagOptions {
-	username := flag.String("u", "", "Username (username@domain)")
+	upn := flag.String("u", "", "Username (username@domain)")
 	password := flag.String("p", "", "Password")
 	ntlm := flag.String("H", "", "Use NTLM authentication")
 	dc := flag.String("dc", "", "IP address or FQDN of target DC")
@@ -47,7 +47,7 @@ func options() *FlagOptions {
 
 	flag.Parse()
 	return &FlagOptions{
-		username: *username,
+		upn: *upn,
 		password: *password,
 		ntlm:     *ntlm,
 		dc:       *dc,
@@ -76,23 +76,21 @@ func main() {
 	var proxyConn net.Conn
 	var err error
 	var domain string
+	var username string
         var target []string	
 
-	target = strings.Split(opt.username, "@")
+	target = strings.Split(opt.upn, "@")
 
 	// Did the user supply the username correctly <user@domain>?
 	if len(target) == 1 {
 	    opt.help = true	
 	}else {
+	    username = target[0]
 	    domain = target[1]
-	    // only include username for ntlm auth
-	    if opt.ntlm != "" {
-                opt.username = target[0]
-	    }
 	}
 	
 	// if required flags aren't set, print help
-	if opt.username == "" || opt.dc == "" || (opt.password == "" && opt.ntlm == "") || opt.help {
+	if username == "" || opt.dc == "" || (opt.password == "" && opt.ntlm == "") || opt.help {
 		flag.Usage()
 		fmt.Println("Examples:")
 		fmt.Println("\tWith Password: \t./ldapper -u <username@domain> -p <password> -dc <ip/FQDN> -s")
@@ -165,7 +163,7 @@ func main() {
 
 	// if password option set
 	if opt.password != "" {
-		err = conn.Bind(opt.username, opt.password) 
+		err = conn.Bind(opt.upn, opt.password) 
 		if err != nil {
 			log.Fatal(err)
 		} else {
@@ -175,7 +173,7 @@ func main() {
 
 	// if ntlm hash option set
 	if opt.ntlm != "" {
-		err = conn.NTLMBindWithHash(domain, opt.username, opt.ntlm) 
+		err = conn.NTLMBindWithHash(domain, username, opt.ntlm) 
 		if err != nil {
 			fmt.Print("test\n")
 			log.Fatal(err)


### PR DESCRIPTION
updated CLI arguments to use "username@domain". NETBIOS name is no longer needed. Also -d flag is no longer needed as the domain should be parsed out from the username argument. Might need to bring the domain flag back for cross domain stuff in the future. 