### PR TITLE
Corrected Flag in Examples

### DIFF
--- a/main.go
+++ b/main.go
@@ -505,9 +505,9 @@ func main() {
 			if c.Flags.String("username") == "" || c.Flags.String("dc") == "" || (c.Flags.String("password") == "" && c.Flags.String("ntlm") == "" && !c.Flags.Bool("kerberos")) {
 				App.Println("Improper usage. Please see sample usage below. For full list of arguments, see \"help connect\"")
 				fmt.Println("Examples:")
-				fmt.Println("\tWith Password: \tconnect -u <username@domain> -p <password> -dc <ip/FQDN> -s")
-				fmt.Println("\tWith Hash: \tconnect -u <username@domain> -H <hash> -dc <ip/FQDN> -s")
-				fmt.Println("\tWith Kerberos: \tconnect -u <username@domain> -k -dc <ip/FQDN> -s\n")
+				fmt.Println("\tWith Password: \tconnect -u <username@domain> -p <password> -d <ip/FQDN> -s")
+				fmt.Println("\tWith Hash: \tconnect -u <username@domain> -H <hash> -d <ip/FQDN> -s")
+				fmt.Println("\tWith Kerberos: \tconnect -u <username@domain> -k -d <ip/FQDN> -s\n")
 				return nil
 			}
 


### PR DESCRIPTION
Small fix but costs 10 minutes to find if looking at the examples in CLI. Examples within tool show `-dc` but the allowed options are `-d` and `--dc`.